### PR TITLE
Fix issue #11: 環境変数ファイルの追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,11 @@ FROM python:3.12-slim
 WORKDIR /app
 
 COPY . /app
+COPY .env /app/.env
+
 
 RUN pip install --no-cache-dir boto3 pandas python-dotenv numpy pytest
+ENV PYTHONUNBUFFERED=1
+
 
 CMD ["python", "script.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # OpenHands-Test2
 
+- `.env` ファイルのサンプル:
+
+  ```env
+  S3_BUCKET=your-bucket
+  S3_PREFIX=your/prefix/
+  LOCAL_DIR=/tmp/data
+  COLUMNS_FILE=columns.txt
+  # 必要に応じて他の変数も追加
+  ```
+
 ## Dockerによる実行方法
+**2025年6月13日更新: Docker実行時の環境変数指定方法を`.env`ファイル方式に変更しました。**
+
 
 ### 1. ビルド
 
@@ -12,16 +24,15 @@ docker build -t s3-batch-app .
 
 ```sh
 docker run --rm -it \
+  --env-file .env \
   -e AWS_ACCESS_KEY_ID=your-access-key \
   -e AWS_SECRET_ACCESS_KEY=your-secret-key \
-  -e S3_BUCKET=your-bucket \
-  -e S3_PREFIX=your/prefix/ \
-  -e LOCAL_DIR=/tmp/data \
-  -e COLUMNS_FILE=columns.txt \
   -v $(pwd):/app \
   s3-batch-app
 ```
 
+- `.env` ファイルに主要な環境変数（S3_BUCKET, S3_PREFIX, LOCAL_DIR, COLUMNS_FILEなど）を記載し、`--env-file .env` で一括指定できます。
+- AWS認証情報（AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY）は `.env` には含めず、`-e` オプションで個別に指定してください。
 - 必要に応じて環境変数を設定してください。
 - `columns.txt` などのファイルも `/app` にマウントされます。
 


### PR DESCRIPTION
This pull request fixes #11.

The issue requested modifying the Docker execution process to specify environment variables via a file rather than individually. The changes made include: (1) updating the Dockerfile to copy the `.env` file into the image, (2) updating the README to provide a sample `.env` file and instructions for using `--env-file .env` with `docker run`, and (3) removing the need to specify each environment variable individually in the Docker run command (except for AWS credentials, which are still set individually for security). These changes ensure that environment variables can now be specified collectively via a `.env` file, as requested. Therefore, the issue has been successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌