### PR TITLE
Fix issue #36: テストのワーニング解消

### DIFF
--- a/modules/check_process.py
+++ b/modules/check_process.py
@@ -68,6 +68,7 @@ def check_values(df, column_types):
             # 文字列型に変換し、欠損値（Noneなど）を空文字で補完
             df[col] = df[col].replace({None: ''}).astype(str).fillna('')
     # 欠損値（NaNなど）を空文字で補完
+    df = df.astype('object')
     df.fillna('', inplace=True)
     # column_typesに含まれない不要カラムを削除
     for col in df.columns:


### PR DESCRIPTION
This pull request fixes #36.

The issue was a FutureWarning from pandas about setting an item of incompatible dtype when using df.fillna('', inplace=True) on a DataFrame with float64 columns. The warning suggests that filling NaN values in float columns with an empty string ('') is deprecated and will raise an error in the future unless the column is explicitly cast to a compatible dtype (such as object). The change made in the PR adds df = df.astype('object') before calling df.fillna('', inplace=True), which converts all columns to object dtype, making it safe to fill NaN values with empty strings. This directly addresses the warning by ensuring dtype compatibility, so the issue is successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌