### PR TITLE
Fix issue #56: AWSエラー対処1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY . /app
 
+RUN mkdir -p /tmp/s3_data /tmp/data
 RUN pip install --no-cache-dir boto3 pandas python-dotenv numpy pytest joblib
 
 CMD ["python", "script.py"]


### PR DESCRIPTION
This pull request fixes #56.

The issue requested that the Dockerfile create the folders /tmp/s3_data and /tmp/data. The change added the line RUN mkdir -p /tmp/s3_data /tmp/data to the Dockerfile, which will create both directories during the image build process. The use of -p ensures the command succeeds even if the directories already exist. This directly addresses the issue as described, so the problem is resolved by this change.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌