### PR TITLE
Fix issue #64: スタブ作成

### DIFF
--- a/bin/box
+++ b/bin/box
@@ -1,0 +1,18 @@
+#!/bin/bash
+# BOX CLI mock wrapper
+if [[ "$1" == "folders:upload" ]]; then
+  if [[ -n "$MOCK_BOX_RTESULT" ]]; then
+    echo "$MOCK_BOX_RTESULT"
+  else
+    echo "box folders:upload mock output"
+  fi
+  exit 0
+else
+  # Fallback to real box if available
+  if command -v box.real >/dev/null 2>&1; then
+    exec box.real "$@"
+  else
+    echo "Error: box.real not found and not a mock command" >&2
+    exit 127
+  fi
+fi

--- a/tests/test_box_mock.sh
+++ b/tests/test_box_mock.sh
@@ -1,0 +1,3 @@
+MOCK_BOX_RTESULT=custom-mock-result /workspace/bin/box folders:upload
+/workspace/bin/box folders:upload
+/workspace/bin/box folders:list || true


### PR DESCRIPTION
This pull request fixes #64.

The changes introduce a bash script at bin/box that acts as a mock for the BOX CLI. When the command box folders:upload is executed, the script checks if the environment variable MOCK_BOX_RTESULT is set; if so, it echoes its value, otherwise it outputs a default mock message and exits successfully. For any other command, the script attempts to delegate to a real box.real command if available, or returns an error if not found. This matches the requirements: mocking only box folders:upload, allowing the mock output to be controlled via an environment variable, and passing through other commands to the real CLI. The included test script demonstrates both the mock and fallback behaviors. Therefore, the issue is resolved as specified.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌