### PR TITLE
Fix issue #92: 単体テスト仕様書修正

### DIFF
--- a/tests/test_s3_download.py
+++ b/tests/test_s3_download.py
@@ -20,6 +20,39 @@ def test_list_csv_files():
         files = list_csv_files('bucket', '', '2025-06-12')
         assert set(files) == {'test/2025-06-12_0900.csv', 'test1/2025-06-12_0900.csv'}
 
+def test_list_csv_files_multiple_objects_one_expected():
+    with patch('boto3.client') as mock_client:
+        mock_s3 = MagicMock()
+        mock_client.return_value = mock_s3
+        mock_s3.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [
+                {'Key': 'test/2025-06-13_0900.csv'},
+                {'Key': 'test/2025-06-13_0910.csv'},
+                {'Key': 'test/2025-06-13_0920.csv'},
+            ]}
+        ]
+        files = list_csv_files('bucket', '', '2025-06-13_0900')
+        assert files == ['test/2025-06-13_0900.csv']
+
+def test_list_csv_files_multiple_objects_multiple_expected():
+    with patch('boto3.client') as mock_client:
+        mock_s3 = MagicMock()
+        mock_client.return_value = mock_s3
+        mock_s3.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [
+                {'Key': 'test/2025-06-13_0914.csv'},
+                {'Key': 'test/2025-06-13_0915.csv'},
+                {'Key': 'test/2025-06-13_0900.csv'},
+                {'Key': 'test/2025-06-13_0920.csv'},
+            ]}
+        ]
+        files = list_csv_files('bucket', '', '2025-06-13_09')
+        # 0900以外の日付
+        assert set(files) == {'test/2025-06-13_0914.csv', 'test/2025-06-13_0915.csv', 'test/2025-06-13_0920.csv', 'test/2025-06-13_0900.csv'}
+        # 0900以外
+        files_ex_0900 = [f for f in files if not f.endswith('0900.csv')]
+        assert set(files_ex_0900) == {'test/2025-06-13_0914.csv', 'test/2025-06-13_0915.csv', 'test/2025-06-13_0920.csv'}
+
 def test_download_csv():
     with patch('boto3.client') as mock_client, tempfile.TemporaryDirectory() as tmpdir:
         mock_s3 = MagicMock()


### PR DESCRIPTION
This pull request fixes #92.

The changes add two new test cases to test_list_csv_files as requested in the issue: one where multiple S3 objects exist but only one is expected as a result, and another where multiple S3 objects exist and multiple are expected, specifically filtering out the "0900" date as described. The first new test (test_list_csv_files_multiple_objects_one_expected) checks that only the file matching "0900" is returned when multiple files are present. The second new test (test_list_csv_files_multiple_objects_multiple_expected) checks that all files matching a broader prefix are returned, and then specifically filters out "0900" to assert the remaining files are as expected. These tests directly address the scenarios described in the issue, ensuring the function behaves correctly in both cases. Therefore, the issue has been successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌