### PR TITLE
Fix issue #94: テストコード修正

### DIFF
--- a/modules/s3_download.py
+++ b/modules/s3_download.py
@@ -25,7 +25,14 @@ def list_csv_files(bucket, prefix, date_str):
             for obj in page['Contents']:
                 key = obj['Key']
                 # 例: test/2025-06-12_0900.csv
-                if key.endswith('.csv') and date_str in os.path.basename(key):
+                base = os.path.basename(key)
+                # フォーマット: YYYY-MM-DD_hhmm.csv
+                if (
+                    key.endswith('.csv')
+                    and date_str in base
+                    and len(base.split('_')) == 2
+                    and base.split('_')[1].endswith('.csv')
+                ):
                     files.append(key)
     return files
 

--- a/tests/test_s3_download.py
+++ b/tests/test_s3_download.py
@@ -20,6 +20,50 @@ def test_list_csv_files():
         files = list_csv_files('bucket', '', '2025-06-12')
         assert set(files) == {'test/2025-06-12_0900.csv', 'test1/2025-06-12_0900.csv'}
 
+
+def test_list_csv_files_cases():
+    with patch('boto3.client') as mock_client:
+        mock_s3 = MagicMock()
+        mock_client.return_value = mock_s3
+        # 様々なパターンのファイルを用意
+        mock_s3.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [
+                {'Key': 'test/2025-06-12_0900.csv'},  # マッチ
+                {'Key': 'test/2025-06-12_1000.csv'},  # マッチ
+                {'Key': 'test/2025-06-11_0900.csv'},  # 別日付
+                {'Key': 'test1/2025-06-12_0900.csv'}, # マッチ
+                {'Key': 'test/2025-06-12_0900.txt'},  # 拡張子違い
+                {'Key': 'test/2025-06-12.csv'},       # フォーマット違い
+                {'Key': 'test/other.txt'},            # 無関係
+                {'Key': 'test2/2025-06-12_0900.csv'}, # マッチ
+                {'Key': 'test/2025-06-12_0900_foo.csv'}, # フォーマット違い
+            ]}
+        ]
+        # 2025-06-12でフィルタ
+        files = list_csv_files('bucket', '', '2025-06-12')
+        # 正しいものだけが返る
+        assert set(files) == {
+            'test/2025-06-12_0900.csv',
+            'test/2025-06-12_1000.csv',
+            'test1/2025-06-12_0900.csv',
+            'test2/2025-06-12_0900.csv',
+        }
+        # 別日付や拡張子違い、フォーマット違いは含まれない
+        assert 'test/2025-06-11_0900.csv' not in files
+        assert 'test/2025-06-12_0900.txt' not in files
+        assert 'test/2025-06-12.csv' not in files
+        assert 'test/other.txt' not in files
+        assert 'test/2025-06-12_0900_foo.csv' not in files
+        # 日付にマッチしない場合は空
+        mock_s3.get_paginator.return_value.paginate.return_value = [
+            {'Contents': [
+                {'Key': 'test/2025-06-11_0900.csv'},
+                {'Key': 'test/2025-06-11_1000.csv'},
+            ]}
+        ]
+        files = list_csv_files('bucket', '', '2025-06-12')
+        assert files == []
+
 def test_download_csv():
     with patch('boto3.client') as mock_client, tempfile.TemporaryDirectory() as tmpdir:
         mock_s3 = MagicMock()


### PR DESCRIPTION
This pull request fixes #94.

The issue requested that changes made to the list_csv_files function (as described in s3_download_unit_test.md) be reflected in the corresponding test code, specifically in tests/test_s3_download.py's test_list_csv_files_cases. The PR updates the list_csv_files function to more strictly match files with the format YYYY-MM-DD_hhmm.csv, ensuring that only files with the correct date and format are included. The test_list_csv_files_cases function is added to comprehensively test various scenarios, including matching and non-matching filenames, different extensions, and incorrect formats. The test asserts that only the correctly formatted and dated files are returned, and that others are excluded. This directly addresses the issue by both updating the implementation and ensuring the test reflects the new logic, confirming the fix is complete and correct.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌